### PR TITLE
Updated build.gradle with support for android 15

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,3 +53,10 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
 }
+
+afterEvaluate { project ->
+    def agpVersion = com.android.builder.model.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.split('\\.')[0].toInteger() >= 8) {
+        android.namespace 'com.appcrashlytics'
+    }
+}


### PR DESCRIPTION
## LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/APPSRN-413

## DESCRIPCIÓN DEL REQUERIMIENTO: *

Se identificó la necesidad de actualizar los packages propios que cuenten con carpeta android con ciertas líneas de código para que, al actualizar las versiones de React y React Native en las APPs los mismos no rompan.

## DESCRIPCIÓN DE LA SOLUCIÓN: *

Se actualizó el build.gradle para dar soporte a Android 15

---

## ¿CÓMO SE PUEDE PROBAR? *

Primero borrando los node_modules tanto del repo al cuál se vinculará cómo el de este repo, eliminar también el android/.gradle y android/build del repo al cuál se vinculará.

Luego, de vincular probar que la app levante funcione correctamente y no rompa ninguna de las funcionalidades relacionadas al package.

<details>
<summary>ℹ️ Información sobre cómo vincular el package</summary>

> **Nota:** Para vincular el package correctamente, asegurarse de contar con [yalc instalado](https://github.com/wclr/yalc)  
> y ejecutar los siguientes comandos desde la raíz del proyecto:
> ```bash
> yalc publish
> ```
> Luego deberemos dirigirnos a la APP con la cuál queramos vincular el package y ejecutar los siguientes comandos:
> ```bash
> yalc add @janiscommerce/app-crashlytics
> npm i --legacy-peer-deps
> ```
</details>

---

## DATOS EXTRA A TENER EN CUENTA:

## CHANGELOG:
